### PR TITLE
Add metrics

### DIFF
--- a/bunjilearn/metrics/CMakeLists.txt
+++ b/bunjilearn/metrics/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_library(metrics
     ${PROJECT_SOURCE_DIR}/loss.cpp
+    ${PROJECT_SOURCE_DIR}/metric.cpp
     )
 
 target_include_directories(metrics PUBLIC ${PROJECT_SOURCE_DIR}/include)

--- a/bunjilearn/metrics/include/loss.hpp
+++ b/bunjilearn/metrics/include/loss.hpp
@@ -1,14 +1,18 @@
 #pragma once
 
 #include "tensor.hpp"
+#include "metric.hpp"
 
-class Loss
+class Loss : public Metric
 {
-private:
+protected:
+    double loss;
 public:
-    Loss() = default;
+    Loss();
+    
     virtual Tensor<double, 3> derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) = 0;
-    virtual double get_loss(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) = 0;
+
+    double evaluate() override;
 };
 
 class SquaredError : public Loss
@@ -17,7 +21,7 @@ private:
 public:
     SquaredError() = default;
     Tensor<double, 3> derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
-    double get_loss(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
+    void update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
 };
 
 class Crossentropy : public Loss
@@ -26,5 +30,5 @@ private:
 public:
     Crossentropy() = default;
     Tensor<double, 3> derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
-    double get_loss(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
+    void update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
 };

--- a/bunjilearn/metrics/include/loss.hpp
+++ b/bunjilearn/metrics/include/loss.hpp
@@ -12,7 +12,8 @@ public:
     
     virtual Tensor<double, 3> derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) = 0;
 
-    double evaluate() override;
+    double evaluate(int example_count) override;
+    std::string get_name() override;
 };
 
 class SquaredError : public Loss

--- a/bunjilearn/metrics/include/metric.hpp
+++ b/bunjilearn/metrics/include/metric.hpp
@@ -1,0 +1,21 @@
+#include "tensor.hpp"
+
+class Metric
+{
+private:
+public:
+    Metric() = default;
+    virtual void update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) = 0;
+    virtual double evaluate() = 0;
+};
+
+class Accuracy : public Metric
+{
+private:
+    int correct;
+    int total;
+public:
+    Accuracy();
+    void update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
+    double evaluate() override;
+};

--- a/bunjilearn/metrics/include/metric.hpp
+++ b/bunjilearn/metrics/include/metric.hpp
@@ -1,4 +1,8 @@
+#pragma once
+
 #include "tensor.hpp"
+
+#include <string>
 
 class Metric
 {
@@ -6,7 +10,8 @@ private:
 public:
     Metric() = default;
     virtual void update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) = 0;
-    virtual double evaluate() = 0;
+    virtual double evaluate(int example_count) = 0;
+    virtual std::string get_name() = 0;
 };
 
 class Accuracy : public Metric
@@ -17,5 +22,6 @@ private:
 public:
     Accuracy();
     void update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output) override;
-    double evaluate() override;
+    double evaluate(int example_count) override;
+    std::string get_name() override;
 };

--- a/bunjilearn/metrics/loss.cpp
+++ b/bunjilearn/metrics/loss.cpp
@@ -7,11 +7,16 @@ Loss::Loss() :
     loss(0.0)
 {}
 
-double Loss::evaluate()
+double Loss::evaluate(int example_count)
 {
-    double result = loss;
+    double result = loss / example_count;
     loss = 0.0;
     return result;
+}
+
+std::string Loss::get_name()
+{
+    return std::string("loss");
 }
 
 Tensor<double, 3> SquaredError::derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)

--- a/bunjilearn/metrics/loss.cpp
+++ b/bunjilearn/metrics/loss.cpp
@@ -3,6 +3,17 @@
 #include <iostream>
 #include <cmath>
 
+Loss::Loss() :
+    loss(0.0)
+{}
+
+double Loss::evaluate()
+{
+    double result = loss;
+    loss = 0.0;
+    return result;
+}
+
 Tensor<double, 3> SquaredError::derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
 {
     Tensor<double, 3> derivative({1, 1, output[0][0].size()});
@@ -15,16 +26,12 @@ Tensor<double, 3> SquaredError::derivative(const Tensor<double, 3> &output, cons
     return derivative;
 }
 
-double SquaredError::get_loss(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
+void SquaredError::update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
 {
-    double loss = 0.0;
-
     for (int i = 0; i < output[0][0].size(); ++i)
     {
         loss += 0.5 * (output[0][0][i] - expected_output[0][0][i]) * (output[0][0][i] - expected_output[0][0][i]);
     }
-
-    return loss;
 }
 
 Tensor<double, 3> Crossentropy::derivative(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
@@ -39,14 +46,10 @@ Tensor<double, 3> Crossentropy::derivative(const Tensor<double, 3> &output, cons
     return derivative;
 }
 
-double Crossentropy::get_loss(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
+void Crossentropy::update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
 {
-    double loss = 0.0;
-
     for (int i = 0; i < output[0][0].size(); ++i)
     {
         loss -= expected_output[0][0][i] * std::log2(output[0][0][i]);
     }
-
-    return loss;
 }

--- a/bunjilearn/metrics/metric.cpp
+++ b/bunjilearn/metrics/metric.cpp
@@ -1,17 +1,18 @@
 #include "metric.hpp"
 
 #include <algorithm>
+#include <iostream>
 
 Accuracy::Accuracy() :
-    correct(0), total(0)
+    correct(0)
 {}
 
 void Accuracy::update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
 {
     int max_pred_index = -1;
-    int max_pred_val = -1.0;
+    double max_pred_val = -1.0;
     int max_expt_index = -1;
-    int max_expt_val = -1.0;
+    double max_expt_val = -1.0;
     for (std::size_t i = 0; i < output[0][0].size(); ++i)
     {
         if (output[0][0][i] > max_pred_val)
@@ -30,12 +31,16 @@ void Accuracy::update(const Tensor<double, 3> &output, const Tensor<double, 3> &
     {
         ++correct;
     }
-    ++total;
 }
 
-double Accuracy::evaluate()
+double Accuracy::evaluate(int example_count)
 {
-    double accuracy = static_cast<double>(correct) / total;
+    double accuracy = static_cast<double>(correct) / example_count;
     correct = 0;
-    total = 0;
+    return accuracy;
+}
+
+std::string Accuracy::get_name()
+{
+    return std::string("accuracy");
 }

--- a/bunjilearn/metrics/metric.cpp
+++ b/bunjilearn/metrics/metric.cpp
@@ -1,0 +1,41 @@
+#include "metric.hpp"
+
+#include <algorithm>
+
+Accuracy::Accuracy() :
+    correct(0), total(0)
+{}
+
+void Accuracy::update(const Tensor<double, 3> &output, const Tensor<double, 3> &expected_output)
+{
+    int max_pred_index = -1;
+    int max_pred_val = -1.0;
+    int max_expt_index = -1;
+    int max_expt_val = -1.0;
+    for (std::size_t i = 0; i < output[0][0].size(); ++i)
+    {
+        if (output[0][0][i] > max_pred_val)
+        {
+            max_pred_val = output[0][0][i];
+            max_pred_index = i;
+        }
+        if (expected_output[0][0][i] > max_expt_val)
+        {
+            max_expt_val = output[0][0][i];
+            max_expt_index = i;
+        }
+    }
+    
+    if (max_pred_index == max_expt_index)
+    {
+        ++correct;
+    }
+    ++total;
+}
+
+double Accuracy::evaluate()
+{
+    double accuracy = static_cast<double>(correct) / total;
+    correct = 0;
+    total = 0;
+}

--- a/bunjilearn/model/include/trainer.hpp
+++ b/bunjilearn/model/include/trainer.hpp
@@ -3,6 +3,7 @@
 #include "network.hpp"
 #include "dataset.hpp"
 #include "loss.hpp"
+#include "metric.hpp"
 
 class Trainer
 {
@@ -10,10 +11,11 @@ private:
     Network *network;
     Dataset *dataset;
     Loss *loss;
+    std::vector<Metric*> metrics;
     double learn_rate;
 public:
-    Trainer(Network *network, Dataset *dataset, Loss *loss, double learn_rate=0.001);
+    Trainer(Network *network, Dataset *dataset, Loss *loss, const std::vector<Metric*> &metrics, double learn_rate=0.001);
     void train_example(const Tensor<double, 3> &input, const Tensor<double, 3> &expected_output);
-    double train_pass();
+    std::vector<double> train_pass();
     void fit(int epochs);
 };

--- a/bunjilearn/model/include/trainer.hpp
+++ b/bunjilearn/model/include/trainer.hpp
@@ -13,7 +13,7 @@ private:
     double learn_rate;
 public:
     Trainer(Network *network, Dataset *dataset, Loss *loss, double learn_rate=0.001);
-    double train_example(const Tensor<double, 3> &input, const Tensor<double, 3> &expected_output);
+    void train_example(const Tensor<double, 3> &input, const Tensor<double, 3> &expected_output);
     double train_pass();
     void fit(int epochs);
 };

--- a/bunjilearn/model/trainer.cpp
+++ b/bunjilearn/model/trainer.cpp
@@ -2,19 +2,23 @@
 
 #include <iostream>
 
-Trainer::Trainer(Network *network, Dataset *dataset, Loss *loss, double learn_rate) :
-    network(network), dataset(dataset), loss(loss), learn_rate(learn_rate)
+Trainer::Trainer(Network *network, Dataset *dataset, Loss *loss, const std::vector<Metric*> &metrics, double learn_rate) :
+    network(network), dataset(dataset), loss(loss), metrics(metrics), learn_rate(learn_rate)
 {}
 
 void Trainer::train_example(const Tensor<double, 3> &input, const Tensor<double, 3> &expected_output)
 {
     Tensor output = network->forward_pass(input);
     loss->update(output, expected_output);
+    for (Metric *metric : metrics)
+    {
+        metric->update(output, expected_output);
+    }
     Tensor output_derivatives = loss->derivative(output, expected_output);
     Tensor input_derivatives = network->backward_pass(input, output_derivatives);
 }
 
-double Trainer::train_pass()
+std::vector<double> Trainer::train_pass()
 {
     for (int i = 0; i < dataset->train_len(); ++i)
     {
@@ -22,16 +26,27 @@ double Trainer::train_pass()
         train_example(example.first, example.second);
     }
     network->apply_gradients(learn_rate / dataset->train_len());
-    double total_loss = loss->evaluate();
 
-    return total_loss / dataset->train_len();
+    std::vector<double> metric_vals(metrics.size());
+
+    for (int i = 0; i < metrics.size(); ++i)
+    {
+        metric_vals[i] = metrics[i]->evaluate(dataset->train_len());
+    }
+
+    return metric_vals;
 }
 
 void Trainer::fit(int epochs)
 {
     for (int i = 0; i < epochs; ++i)
     {
-        double network_loss = train_pass();
-        std::cout << "Epoch: " << i << " Loss: " << network_loss << std::endl;
+        std::vector<double> metric_vals = train_pass();
+        std::cout << "Epoch: " << i;
+        for (int i = 0; i < metrics.size(); ++i)
+        {
+            std::cout << '\t' << metrics[i]->get_name() << ':' << metric_vals[i];
+        }
+        std::cout << std::endl;
     }
 }

--- a/bunjilearn/model/trainer.cpp
+++ b/bunjilearn/model/trainer.cpp
@@ -6,25 +6,24 @@ Trainer::Trainer(Network *network, Dataset *dataset, Loss *loss, double learn_ra
     network(network), dataset(dataset), loss(loss), learn_rate(learn_rate)
 {}
 
-double Trainer::train_example(const Tensor<double, 3> &input, const Tensor<double, 3> &expected_output)
+void Trainer::train_example(const Tensor<double, 3> &input, const Tensor<double, 3> &expected_output)
 {
     Tensor output = network->forward_pass(input);
-    double network_loss = loss->get_loss(output, expected_output);
+    loss->update(output, expected_output);
     Tensor output_derivatives = loss->derivative(output, expected_output);
     Tensor input_derivatives = network->backward_pass(input, output_derivatives);
-
-    return network_loss;
 }
 
 double Trainer::train_pass()
 {
-    double total_loss = 0.0;
     for (int i = 0; i < dataset->train_len(); ++i)
     {
         std::pair<Tensor<double, 3>, Tensor<double, 3>> example = dataset->train(i);
-        total_loss += train_example(example.first, example.second);
+        train_example(example.first, example.second);
     }
     network->apply_gradients(learn_rate / dataset->train_len());
+    double total_loss = loss->evaluate();
+
     return total_loss / dataset->train_len();
 }
 

--- a/mains/main.cpp
+++ b/mains/main.cpp
@@ -4,6 +4,7 @@
 #include "network.hpp"
 #include "trainer.hpp"
 #include "loss.hpp"
+#include "metric.hpp"
 #include "flatten.hpp"
 
 #include "config.h"
@@ -32,7 +33,12 @@ int main(int argc, char **argv)
 
     Crossentropy loss;
 
-    Trainer network_trainer(&network, &dataset, &loss, 5);
+    Crossentropy loss_metric;
+    Accuracy acc_metric;
+    
+    std::vector<Metric*> metrics = {&loss_metric, &acc_metric};
+
+    Trainer network_trainer(&network, &dataset, &loss, metrics, 5);
 
     network_trainer.fit(1000000);
     


### PR DESCRIPTION
An abstract class `Metric` has been made for all metrics, from which the `Loss` class has been derived from. `Metric` implements three virtual functions.

- `update` : udpates the state of the metric with a recently computed output of the neural network.
- `compute` : determines the values of the metric given its current state and resets the state.
- `get_name` : returns a `std::string` of the metric's name.

The layer class defines the `get_name` and `compute` functions, leaving `update` and the virtual function defined by `Loss`, `derivative` for classes deriving from `Loss` to implement.

The `Trainer` takes in a `std::vector` of poitners to metrics which it uses to give information on training progress. This partially closes issue id 5 (more work will be done on this), and completely closes #6  

