### PR TITLE
Layer build

### DIFF
--- a/bunjilearn/layers/activation.cpp
+++ b/bunjilearn/layers/activation.cpp
@@ -6,6 +6,21 @@
 namespace bunji
 {
 
+Activation::Activation() :
+    x(0), y(0), z(0)
+{}
+
+Activation::Activation(std::size_t x, std::size_t y, std::size_t z) :
+    x(x), y(y), z(z)
+{}
+
+void Activation::build(std::size_t xn, std::size_t yn, std::size_t zn)
+{
+    x = xn;
+    y = yn;
+    z = zn;
+}
+
 Tensor<double, 3> ReLU::forward_pass(const Tensor<double, 3> &input)
 {
     std::size_t inputs = input[0][0].size();

--- a/bunjilearn/layers/activation.cpp
+++ b/bunjilearn/layers/activation.cpp
@@ -7,11 +7,11 @@ namespace bunji
 {
 
 Activation::Activation() :
-    x(0), y(0), z(0)
+    x(0), y(0), z(0), built(false)
 {}
 
 Activation::Activation(std::size_t x, std::size_t y, std::size_t z) :
-    x(x), y(y), z(z)
+    x(x), y(y), z(z), built(false)
 {}
 
 void Activation::build(std::size_t xn, std::size_t yn, std::size_t zn)
@@ -19,6 +19,12 @@ void Activation::build(std::size_t xn, std::size_t yn, std::size_t zn)
     x = xn;
     y = yn;
     z = zn;
+    built = true;
+}
+
+std::tuple<std::size_t, std::size_t, std::size_t> Activation::output_shape()
+{
+    return std::make_tuple(x, y, z);
 }
 
 Tensor<double, 3> ReLU::forward_pass(const Tensor<double, 3> &input)

--- a/bunjilearn/layers/activation.cpp
+++ b/bunjilearn/layers/activation.cpp
@@ -7,24 +7,25 @@ namespace bunji
 {
 
 Activation::Activation() :
-    x(0), y(0), z(0), built(false)
-{}
-
-Activation::Activation(std::size_t x, std::size_t y, std::size_t z) :
-    x(x), y(y), z(z), built(false)
-{}
-
-void Activation::build(std::size_t xn, std::size_t yn, std::size_t zn)
+    x(0), y(0), z(0)
 {
-    x = xn;
-    y = yn;
-    z = zn;
-    built = true;
+    built = false;
 }
 
-std::tuple<std::size_t, std::size_t, std::size_t> Activation::output_shape()
+Activation::Activation(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
 {
-    return std::make_tuple(x, y, z);
+    built = false;
+    build(set_input_shape);
+}
+
+void Activation::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
+{
+    input_shape = set_input_shape;
+    x = std::get<0>(set_input_shape);
+    y = std::get<1>(set_input_shape);
+    z = std::get<2>(set_input_shape);
+    output_shape = std::make_tuple(x, y, z);
+    built = true;
 }
 
 Tensor<double, 3> ReLU::forward_pass(const Tensor<double, 3> &input)

--- a/bunjilearn/layers/dense.cpp
+++ b/bunjilearn/layers/dense.cpp
@@ -7,11 +7,11 @@ namespace bunji
 {
 
 Dense::Dense(int units) :
-    units(units)
+    units(units), built(false)
 {}
 
 Dense::Dense(int input, int units) :
-    units(units)
+    units(units), built(false)
 {
     build(1, 1, input);
 }
@@ -39,6 +39,14 @@ void Dense::build(std::size_t x, std::size_t y, std::size_t z)
             weight = dist(gen);
         }
     }
+
+    built = true;
+}
+
+std::tuple<std::size_t, std::size_t, std::size_t> Dense::output_shape()
+{
+    std::size_t unit_count = weights.size();
+    return std::make_tuple(1, 1, unit_count);
 }
 
 Tensor<double, 3> Dense::forward_pass(const Tensor<double, 3> &input)

--- a/bunjilearn/layers/dense.cpp
+++ b/bunjilearn/layers/dense.cpp
@@ -7,22 +7,26 @@ namespace bunji
 {
 
 Dense::Dense(int units) :
-    units(units), built(false)
-{}
+    units(units)
+{
+    built = false;
+}
 
 Dense::Dense(int input, int units) :
-    units(units), built(false)
+    units(units)
 {
-    build(1, 1, input);
+    built = false;
+    build(std::make_tuple(1, 1, input));
 }
-void Dense::build(std::size_t x, std::size_t y, std::size_t z)
+void Dense::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
 {
-    if (x != 1 || y != 1)
+    input_shape = set_input_shape;
+    if (std::get<0>(set_input_shape) != 1 || std::get<1>(set_input_shape) != 1)
     {
-        BUNJI_WRN("cannot build dense layer with input shape ({},{},{})", x, y, z);
+        BUNJI_WRN("cannot build dense layer with input shape ({},{},{})", std::get<0>(set_input_shape), std::get<1>(set_input_shape), std::get<2>(set_input_shape));
         return;
     }
-    const int input = z;
+    const int input = std::get<2>(set_input_shape);
 
     weights = std::vector<std::vector<double>>(units, std::vector<double>(input,0.0));
     deriv_weights = std::vector<std::vector<double>>(units, std::vector<double>(input,0.0));
@@ -40,13 +44,9 @@ void Dense::build(std::size_t x, std::size_t y, std::size_t z)
         }
     }
 
+    output_shape = std::make_tuple(1, 1, units);
+    
     built = true;
-}
-
-std::tuple<std::size_t, std::size_t, std::size_t> Dense::output_shape()
-{
-    std::size_t unit_count = weights.size();
-    return std::make_tuple(1, 1, unit_count);
 }
 
 Tensor<double, 3> Dense::forward_pass(const Tensor<double, 3> &input)

--- a/bunjilearn/layers/dense.cpp
+++ b/bunjilearn/layers/dense.cpp
@@ -1,17 +1,34 @@
 #include "dense.hpp"
+#include "log.hpp"
 
 #include <random>
-#include <iostream>
 
 namespace bunji
 {
 
+Dense::Dense(int units) :
+    units(units)
+{}
+
 Dense::Dense(int input, int units) :
-    weights(units, std::vector<double>(input,0.0)),
-    deriv_weights(units, std::vector<double>(input,0.0)),
-    biases(units, 0.0),
-    deriv_biases(units, 0.0)
+    units(units)
 {
+    build(1, 1, input);
+}
+void Dense::build(std::size_t x, std::size_t y, std::size_t z)
+{
+    if (x != 1 || y != 1)
+    {
+        BUNJI_WRN("cannot build dense layer with input shape ({},{},{})", x, y, z);
+        return;
+    }
+    const int input = z;
+
+    weights = std::vector<std::vector<double>>(units, std::vector<double>(input,0.0));
+    deriv_weights = std::vector<std::vector<double>>(units, std::vector<double>(input,0.0));
+    biases = std::vector<double>(units, 0.0);
+    deriv_biases = std::vector<double>(units, 0.0);
+    
     std::default_random_engine gen;
     std::uniform_real_distribution<double> dist(-1.0, 1.0);
     
@@ -59,7 +76,7 @@ Tensor<double, 3> Dense::backward_pass(const Tensor<double, 3> &input, const Ten
     /* checking that the output derivatives are a valid size */
     if (output_size != units)
     {
-        std::cerr << "output size does not match units" << std::endl;
+        BUNJI_WRN("output size {} does not match unit count {}", output_size, units);
         return Tensor<double, 3>({1, 1, 1});
     }
     

--- a/bunjilearn/layers/flatten.cpp
+++ b/bunjilearn/layers/flatten.cpp
@@ -5,27 +5,26 @@
 namespace bunji
 {
 
-Flatten::Flatten(int d, int h, int w) :
-    built(false)
+Flatten::Flatten(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
 {
-    build(d, h, w);
+    built = false;
+    build(set_input_shape);
 }
 
 Flatten::Flatten() :
-    d(0), h(0), w(0), built(false)
-{}
-
-void Flatten::build(std::size_t x, std::size_t y, std::size_t z)
+    d(0), h(0), w(0)
 {
-    d = x;
-    h = y;
-    w = z;
-    built = true;
+    built = false;
 }
 
-std::tuple<std::size_t, std::size_t, std::size_t> Flatten::output_shape()
+void Flatten::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
 {
-    return std::make_tuple(1, 1, d * h * w);
+    input_shape = set_input_shape;
+    d = std::get<0>(set_input_shape);
+    h = std::get<1>(set_input_shape);
+    w = std::get<2>(set_input_shape);
+    output_shape = std::make_tuple(1, 1, d * h * w);
+    built = true;
 }
 
 Tensor<double, 3> Flatten::forward_pass(const Tensor<double, 3> &input)

--- a/bunjilearn/layers/flatten.cpp
+++ b/bunjilearn/layers/flatten.cpp
@@ -5,9 +5,21 @@
 namespace bunji
 {
 
-Flatten::Flatten(int d, int h, int w) :
-    d(d), h(h), w(w)
+Flatten::Flatten(int d, int h, int w)
+{
+    build(d, h, w);
+}
+
+Flatten::Flatten() :
+    d(0), h(0), w(0)
 {}
+
+void Flatten::build(std::size_t x, std::size_t y, std::size_t z)
+{
+    d = x;
+    h = y;
+    w = z;
+}
 
 Tensor<double, 3> Flatten::forward_pass(const Tensor<double, 3> &input)
 {

--- a/bunjilearn/layers/flatten.cpp
+++ b/bunjilearn/layers/flatten.cpp
@@ -5,13 +5,14 @@
 namespace bunji
 {
 
-Flatten::Flatten(int d, int h, int w)
+Flatten::Flatten(int d, int h, int w) :
+    built(false)
 {
     build(d, h, w);
 }
 
 Flatten::Flatten() :
-    d(0), h(0), w(0)
+    d(0), h(0), w(0), built(false)
 {}
 
 void Flatten::build(std::size_t x, std::size_t y, std::size_t z)
@@ -19,6 +20,12 @@ void Flatten::build(std::size_t x, std::size_t y, std::size_t z)
     d = x;
     h = y;
     w = z;
+    built = true;
+}
+
+std::tuple<std::size_t, std::size_t, std::size_t> Flatten::output_shape()
+{
+    return std::make_tuple(1, 1, d * h * w);
 }
 
 Tensor<double, 3> Flatten::forward_pass(const Tensor<double, 3> &input)

--- a/bunjilearn/layers/include/activation.hpp
+++ b/bunjilearn/layers/include/activation.hpp
@@ -8,8 +8,12 @@ namespace bunji
 class Activation : public Layer
 {
 private:
+protected:
+    std::size_t x, y, z;
 public:
-    Activation() = default;
+    Activation();
+    Activation(std::size_t x, std::size_t y, std::size_t z);
+    void build(std::size_t x, std::size_t y, std::size_t z) override;
 
     /* Activation layers have no parameters */
     void apply_gradients(double learn_rate) override {}

--- a/bunjilearn/layers/include/activation.hpp
+++ b/bunjilearn/layers/include/activation.hpp
@@ -14,6 +14,7 @@ public:
     Activation();
     Activation(std::size_t x, std::size_t y, std::size_t z);
     void build(std::size_t x, std::size_t y, std::size_t z) override;
+    std::tuple<std::size_t, std::size_t, std::size_t> output_shape() override;
 
     /* Activation layers have no parameters */
     void apply_gradients(double learn_rate) override {}

--- a/bunjilearn/layers/include/activation.hpp
+++ b/bunjilearn/layers/include/activation.hpp
@@ -12,9 +12,8 @@ protected:
     std::size_t x, y, z;
 public:
     Activation();
-    Activation(std::size_t x, std::size_t y, std::size_t z);
-    void build(std::size_t x, std::size_t y, std::size_t z) override;
-    std::tuple<std::size_t, std::size_t, std::size_t> output_shape() override;
+    Activation(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape);
+    void build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape) override;
 
     /* Activation layers have no parameters */
     void apply_gradients(double learn_rate) override {}

--- a/bunjilearn/layers/include/dense.hpp
+++ b/bunjilearn/layers/include/dense.hpp
@@ -17,6 +17,7 @@ public:
     Dense(int units);
     Dense(int inputs, int units);
     void build(std::size_t x, std::size_t y, std::size_t z) override;
+    std::tuple<std::size_t, std::size_t, std::size_t> output_shape() override;
 
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) override;
     Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives) override;

--- a/bunjilearn/layers/include/dense.hpp
+++ b/bunjilearn/layers/include/dense.hpp
@@ -8,12 +8,16 @@ namespace bunji
 class Dense : public Layer
 {
 private:
+    int units;
     std::vector<std::vector<double>> weights;
     std::vector<std::vector<double>> deriv_weights;
     std::vector<double> biases;
     std::vector<double> deriv_biases;
 public:
+    Dense(int units);
     Dense(int inputs, int units);
+    void build(std::size_t x, std::size_t y, std::size_t z) override;
+
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) override;
     Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives) override;
 

--- a/bunjilearn/layers/include/dense.hpp
+++ b/bunjilearn/layers/include/dense.hpp
@@ -16,8 +16,7 @@ private:
 public:
     Dense(int units);
     Dense(int inputs, int units);
-    void build(std::size_t x, std::size_t y, std::size_t z) override;
-    std::tuple<std::size_t, std::size_t, std::size_t> output_shape() override;
+    void build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape) override;
 
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) override;
     Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives) override;

--- a/bunjilearn/layers/include/flatten.hpp
+++ b/bunjilearn/layers/include/flatten.hpp
@@ -13,6 +13,7 @@ public:
     Flatten();
     Flatten(int d, int h, int w);
     void build(std::size_t x, std::size_t y, std::size_t z) override;
+    std::tuple<std::size_t, std::size_t, std::size_t> output_shape() override;
 
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input);
     Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives);

--- a/bunjilearn/layers/include/flatten.hpp
+++ b/bunjilearn/layers/include/flatten.hpp
@@ -11,9 +11,8 @@ private:
     int d, h, w;
 public:
     Flatten();
-    Flatten(int d, int h, int w);
-    void build(std::size_t x, std::size_t y, std::size_t z) override;
-    std::tuple<std::size_t, std::size_t, std::size_t> output_shape() override;
+    Flatten(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape);
+    void build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape) override;
 
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input);
     Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives);

--- a/bunjilearn/layers/include/flatten.hpp
+++ b/bunjilearn/layers/include/flatten.hpp
@@ -10,7 +10,10 @@ class Flatten : public Layer
 private:
     int d, h, w;
 public:
+    Flatten();
     Flatten(int d, int h, int w);
+    void build(std::size_t x, std::size_t y, std::size_t z) override;
+
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input);
     Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives);
 

--- a/bunjilearn/layers/include/layer.hpp
+++ b/bunjilearn/layers/include/layer.hpp
@@ -2,6 +2,8 @@
 
 #include "tensor.hpp"
 
+#include <tuple>
+
 namespace bunji
 {
 
@@ -16,10 +18,12 @@ class Layer
 private:
 protected:
     Tensor<double, 3> activations;
+    bool built;
 public:
     Layer();
 
     virtual void build(std::size_t x, std::size_t y, std::size_t z) = 0;
+    virtual std::tuple<std::size_t, std::size_t, std::size_t> output_shape() = 0;
 
     virtual Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) = 0;
     virtual Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives) = 0;

--- a/bunjilearn/layers/include/layer.hpp
+++ b/bunjilearn/layers/include/layer.hpp
@@ -18,12 +18,15 @@ class Layer
 private:
 protected:
     Tensor<double, 3> activations;
-    bool built;
+    std::tuple<std::size_t, std::size_t, std::size_t> input_shape;
+    std::tuple<std::size_t, std::size_t, std::size_t> output_shape;
 public:
+    bool built;
     Layer();
 
-    virtual void build(std::size_t x, std::size_t y, std::size_t z) = 0;
-    virtual std::tuple<std::size_t, std::size_t, std::size_t> output_shape() = 0;
+    virtual void build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape) = 0;
+    std::tuple<std::size_t, std::size_t, std::size_t> get_output_shape();
+    std::tuple<std::size_t, std::size_t, std::size_t> get_input_shape();
 
     virtual Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) = 0;
     virtual Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives) = 0;

--- a/bunjilearn/layers/include/layer.hpp
+++ b/bunjilearn/layers/include/layer.hpp
@@ -19,6 +19,8 @@ protected:
 public:
     Layer();
 
+    virtual void build(std::size_t x, std::size_t y, std::size_t z) = 0;
+
     virtual Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) = 0;
     virtual Tensor<double, 3> backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives) = 0;
 

--- a/bunjilearn/layers/layer.cpp
+++ b/bunjilearn/layers/layer.cpp
@@ -12,4 +12,13 @@ Tensor<double, 3> Layer::get_activations() const
     return activations;
 }
 
+std::tuple<std::size_t, std::size_t, std::size_t> Layer::get_output_shape()
+{
+    return output_shape;
+}
+std::tuple<std::size_t, std::size_t, std::size_t> Layer::get_input_shape()
+{
+    return input_shape;
+}
+
 } // namespace bunji

--- a/bunjilearn/model/include/network.hpp
+++ b/bunjilearn/model/include/network.hpp
@@ -19,6 +19,7 @@ public:
     void apply_gradients(double learn_rate);
 
     void add_layer(Layer *layer);
+    void build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape);
 };
 
 } // namespace bunji

--- a/bunjilearn/model/network.cpp
+++ b/bunjilearn/model/network.cpp
@@ -1,6 +1,5 @@
 #include "network.hpp"
-
-#include <iostream>
+#include "log.hpp"
 
 namespace bunji
 {
@@ -45,6 +44,29 @@ void Network::apply_gradients(double learn_rate)
 void Network::add_layer(Layer *layer)
 {
     layers.push_back(layer);
+}
+
+void Network::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
+{
+    std::tuple<std::size_t, std::size_t, std::size_t> next_input = set_input_shape;
+    BUNJI_ERR("x:{}, y:{}, z:{}", std::get<0>(next_input), std::get<1>(next_input), std::get<2>(next_input));
+    for (Layer *layer : layers)
+    {
+        if (layer->built)
+        {
+            if (layer->get_input_shape() != next_input)
+            {
+                BUNJI_WRN("layer built with incorrect input shape");
+                return;
+            }
+        }
+        else
+        {
+            layer->build(next_input);
+            next_input = layer->get_output_shape();
+        }
+        BUNJI_ERR("x:{}, y:{}, z:{}", std::get<0>(next_input), std::get<1>(next_input), std::get<2>(next_input));
+    }
 }
 
 } // namespace bunji

--- a/mains/main.cpp
+++ b/mains/main.cpp
@@ -20,10 +20,10 @@ int main(int argc, char **argv)
 
     bunji::Network network;
 
-    bunji::Flatten f0(1, 28, 28);
-    bunji::Dense d0(784, 256);
+    bunji::Flatten f0;
+    bunji::Dense d0(256);
     bunji::Sigmoid a0;
-    bunji::Dense d1(256, 10);
+    bunji::Dense d1(10);
     bunji::Softmax a1;
 
     network.add_layer(&f0);
@@ -31,6 +31,7 @@ int main(int argc, char **argv)
     network.add_layer(&a0);
     network.add_layer(&d1);
     network.add_layer(&a1);
+    network.build(std::make_tuple(1, 28, 28));
 
     bunji::Crossentropy loss;
 


### PR DESCRIPTION
Two member variables have been added to the `Layer` class, `input_shape` and `output_shape`. These variables must be set by every layer in its implementation of `virtual Layer::build()`.

The `Network::build` function has been added which loops through the layers, building them if not already build, and checking the shape of them if the layers are already built.