### PR TITLE
Clean nn ops

### DIFF
--- a/bunjilearn/layers/activation.cpp
+++ b/bunjilearn/layers/activation.cpp
@@ -25,31 +25,39 @@ void Activation::build(std::tuple<std::size_t, std::size_t, std::size_t> set_inp
     y = std::get<1>(set_input_shape);
     z = std::get<2>(set_input_shape);
     output_shape = std::make_tuple(x, y, z);
+    activations = Tensor<double, 3>({x, y, z});
     built = true;
 }
 
 Tensor<double, 3> ReLU::forward_pass(const Tensor<double, 3> &input)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> output({1, 1, inputs});
-
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        output[0][0][i] = std::max(0.0, input[0][0][i]);
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                activations[i][j][k] = std::max(0.0, input[i][j][k]);
+            }
+        }
     }
-
-    activations = output;
-    return output;
+    
+    return activations;
 }
 
 Tensor<double, 3> ReLU::backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> input_derivatives({1, 1, inputs});
+    Tensor<double, 3> input_derivatives({std::get<0>(input_shape), std::get<1>(input_shape), std::get<2>(input_shape)});
 
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        input_derivatives[0][0][i] = output_derivatives[0][0][i] * (input[0][0][i] > 0) ? 1 : 0;
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                input_derivatives[i][j][k] = output_derivatives[i][j][k] * (input[i][j][k] > 0) ? 1 : 0;
+            }
+        }
     }
 
     return input_derivatives;
@@ -59,26 +67,33 @@ Tensor<double, 3> ReLU::backward_pass(const Tensor<double, 3> &input, const Tens
 
 Tensor<double, 3> Sigmoid::forward_pass(const Tensor<double, 3> &input)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> output({1, 1, inputs});
-
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        output[0][0][i] = 1.0 / (1.0 + std::exp(-input[0][0][i]));
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                activations[i][j][k] = 1.0 / (1.0 + std::exp(-input[i][j][k]));
+            }
+        }
     }
-
-    activations = output;
-    return output;
+    
+    return activations;
 }
 
 Tensor<double, 3> Sigmoid::backward_pass(const Tensor<double, 3> &input, const Tensor <double, 3>&output_derivatives)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> input_derivatives({1, 1, inputs});
+    Tensor<double, 3> input_derivatives({std::get<0>(input_shape), std::get<1>(input_shape), std::get<2>(input_shape)});
 
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        input_derivatives[0][0][i] = output_derivatives[0][0][i] * activations[0][0][i] * (1 - activations[0][0][i]);
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                input_derivatives[i][j][k] = output_derivatives[i][j][k] * activations[i][j][k] * (1 - activations[i][j][k]);
+            }
+        }
     }
 
     return input_derivatives;
@@ -88,65 +103,83 @@ Tensor<double, 3> Sigmoid::backward_pass(const Tensor<double, 3> &input, const T
 
 Tensor<double, 3> Tanh::forward_pass(const Tensor<double, 3> &input)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> output({1, 1, inputs});
-
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        output[0][0][i] = std::tanh(input[0][0][i]);
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                activations[i][j][k] = std::tanh(input[i][j][k]);
+            }
+        }
     }
-
-    activations = output;
-    return output;
+    
+    return activations;
 }
 
 Tensor<double, 3> Tanh::backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> input_derivatives({1, 1, inputs});
+    Tensor<double, 3> input_derivatives({std::get<0>(input_shape), std::get<1>(input_shape), std::get<2>(input_shape)});
 
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        input_derivatives[0][0][i] = output_derivatives[0][0][i] * (1 - activations[0][0][i] * activations[0][0][i]);
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                input_derivatives[i][j][k] = output_derivatives[i][j][k] * (1 - activations[i][j][k] * activations[i][j][k]);
+            }
+        }
     }
 
     return input_derivatives;
 }
 
 
-
+/*
+ * It doesnt really makes sense to use softmax on an input which is more
+ * than 1 dimension, other than potentially trying to estimate many random
+ * variables, and so each vector in the deepest axis will be considered
+ * as a separate random variable.
+ */
 Tensor<double, 3> Softmax::forward_pass(const Tensor<double, 3> &input)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> output({1, 1, inputs});
-
-    double sum = 0.0;
-    for (int i = 0; i < inputs; i++)
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        sum += std::exp(input[0][0][i]);
-    }
-    for (int i = 0; i < inputs; i++)
-    {
-        output[0][0][i] = std::exp(input[0][0][i]) / sum;
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
+        {
+            double sum = 0.0;
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                sum += std::exp(input[i][j][k]);
+            }
+            for (std::size_t k = 0; k < std::get<2>(input_shape); ++k)
+            {
+                activations[i][j][k] = std::exp(input[i][j][k]) / sum;
+            }
+        }
     }
 
-    activations = output;
-    return output;
+    return activations;
 }
 
 Tensor<double, 3> Softmax::backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives)
 {
-    std::size_t inputs = input[0][0].size();
-    Tensor<double, 3> input_derivatives({1, 1, inputs});
-
-    for (int i = 0; i < inputs; i++)
+    Tensor<double, 3> input_derivatives({std::get<0>(input_shape), std::get<1>(input_shape), std::get<2>(input_shape)});
+    
+    for (std::size_t i = 0; i < std::get<0>(input_shape); ++i)
     {
-        for (int j = 0; j < inputs; j++)
+        for (std::size_t j = 0; j < std::get<1>(input_shape); ++j)
         {
-            input_derivatives[0][0][j] += output_derivatives[0][0][i] * activations[0][0][i] * ((j == i ? 1.0 : 0.0) - activations[0][0][j]);
+            for (std::size_t k = 0; k < std::get<2>(input_shape); k++)
+            {
+                for (std::size_t l = 0; l < std::get<2>(input_shape); l++)
+                {
+                    input_derivatives[i][j][l] += output_derivatives[i][j][k] * activations[i][j][k] * ((l == k ? 1.0 : 0.0) - activations[i][j][l]);
+                }
+            }
         }
     }
-    
 
     return input_derivatives;
 }

--- a/bunjilearn/layers/dense.cpp
+++ b/bunjilearn/layers/dense.cpp
@@ -45,6 +45,7 @@ void Dense::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_sh
     }
 
     output_shape = std::make_tuple(1, 1, units);
+    activations = Tensor<double, 3>({1, 1, units});
     
     built = true;
 }

--- a/bunjilearn/layers/dense.cpp
+++ b/bunjilearn/layers/dense.cpp
@@ -45,56 +45,38 @@ void Dense::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_sh
     }
 
     output_shape = std::make_tuple(1, 1, units);
-    activations = Tensor<double, 3>({1, 1, units});
+    activations = Tensor<double, 3>({1, 1, static_cast<size_t>(units)});
     
     built = true;
 }
 
 Tensor<double, 3> Dense::forward_pass(const Tensor<double, 3> &input)
 {
-    const std::size_t units = weights.size();
-    const std::size_t input_size = input[0][0].size();
-
-    /* initialize a tensor for the output */
-    Tensor<double, 3> output({1, 1, units});
-
-    for (int i = 0; i < units; ++i)
+    for (std::size_t i = 0; i < units; ++i)
     {
         /* calculate the dot product of the input and weights */
         double sum = 0.0;
-        for (int j = 0; j < input_size; ++j)
+        for (std::size_t j = 0; j < std::get<2>(input_shape); ++j)
         {
             sum += input[0][0][j] * weights[i][j];
         }
         sum += biases[i];
 
         /* add to the output vector */
-        output[0][0][i] = sum;
+        activations[0][0][i] = sum;
     }
 
-    activations = output;
-    return output;
+    return activations;
 }
 
 Tensor<double, 3> Dense::backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives)
-{
-    const std::size_t units = weights.size();
-    const std::size_t input_size = input[0][0].size();
-    const std::size_t output_size = output_derivatives[0][0].size();
-
-    /* checking that the output derivatives are a valid size */
-    if (output_size != units)
-    {
-        BUNJI_WRN("output size {} does not match unit count {}", output_size, units);
-        return Tensor<double, 3>({1, 1, 1});
-    }
-    
+{    
     /* initialize a tensor for the output */
-    Tensor<double, 3> deriv_input({1, 1, input_size});
+    Tensor<double, 3> deriv_input({1, 1, std::get<2>(input_shape)});
     
-    for (int i = 0; i < units; ++i)
+    for (std::size_t i = 0; i < units; ++i)
     {
-        for (int j = 0; j < input_size; ++j)
+        for (std::size_t j = 0; j < std::get<2>(input_shape); ++j)
         {
             /* weight derivative calculation */
             deriv_weights[i][j] += input[0][0][j] * output_derivatives[0][0][i];
@@ -112,17 +94,13 @@ Tensor<double, 3> Dense::backward_pass(const Tensor<double, 3> &input, const Ten
 
 void Dense::apply_gradients(double learn_rate)
 {
-    for (int i = 0; i < weights.size(); ++i)
+    for (std::size_t i = 0; i < units; ++i)
     {
-        for (int j = 0; j < weights[i].size(); ++j)
+        for (std::size_t j = 0; j < std::get<2>(input_shape); ++j)
         {
             weights[i][j] -= deriv_weights[i][j] * learn_rate;
             deriv_weights[i][j] = 0.0;
         }
-    }
-
-    for (int i = 0; i < biases.size(); ++i)
-    {
         biases[i] -= deriv_biases[i] * learn_rate;
         deriv_biases[i] = 0.0;
     }

--- a/bunjilearn/layers/dense.cpp
+++ b/bunjilearn/layers/dense.cpp
@@ -6,13 +6,13 @@
 namespace bunji
 {
 
-Dense::Dense(int units) :
+Dense::Dense(std::size_t units) :
     units(units)
 {
     built = false;
 }
 
-Dense::Dense(int input, int units) :
+Dense::Dense(std::size_t input, std::size_t units) :
     units(units)
 {
     built = false;
@@ -21,22 +21,22 @@ Dense::Dense(int input, int units) :
 void Dense::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
 {
     input_shape = set_input_shape;
-    if (std::get<0>(set_input_shape) != 1 || std::get<1>(set_input_shape) != 1)
+    if (std::get<0>(input_shape) != 1 || std::get<1>(input_shape) != 1)
     {
-        BUNJI_WRN("cannot build dense layer with input shape ({},{},{})", std::get<0>(set_input_shape), std::get<1>(set_input_shape), std::get<2>(set_input_shape));
+        BUNJI_WRN("cannot build dense layer with input shape ({},{},{})", std::get<0>(input_shape), std::get<1>(input_shape), std::get<2>(input_shape));
         return;
     }
-    const int input = std::get<2>(set_input_shape);
+    const std::size_t input = std::get<2>(input_shape);
 
-    weights = std::vector<std::vector<double>>(units, std::vector<double>(input,0.0));
-    deriv_weights = std::vector<std::vector<double>>(units, std::vector<double>(input,0.0));
-    biases = std::vector<double>(units, 0.0);
-    deriv_biases = std::vector<double>(units, 0.0);
+    weights = Tensor<double, 2>({units, input});
+    deriv_weights = Tensor<double, 2>({units, input});
+    biases = Tensor<double, 1>({units});
+    deriv_biases = Tensor<double, 1>({units});
     
     std::default_random_engine gen;
     std::uniform_real_distribution<double> dist(-1.0, 1.0);
     
-    for (std::vector<double> &unit_weights : weights)
+    for (auto unit_weights : weights)
     {
         for (double &weight : unit_weights)
         {
@@ -45,7 +45,7 @@ void Dense::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_sh
     }
 
     output_shape = std::make_tuple(1, 1, units);
-    activations = Tensor<double, 3>({1, 1, static_cast<size_t>(units)});
+    activations = Tensor<double, 3>({1, 1, units});
     
     built = true;
 }

--- a/bunjilearn/layers/flatten.cpp
+++ b/bunjilearn/layers/flatten.cpp
@@ -30,22 +30,19 @@ void Flatten::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_
 
 Tensor<double, 3> Flatten::forward_pass(const Tensor<double, 3> &input)
 {
-    Tensor<double, 3> output({1, 1, static_cast<std::size_t>(d * h * w)});
-
     std::size_t index = 0;
-    for (int i = 0; i < d; ++i)
+    for (std::size_t i = 0; i < d; ++i)
     {
-        for (int j = 0; j < h; ++j)
+        for (std::size_t j = 0; j < h; ++j)
         {
-            for (int k = 0; k < w; ++k)
+            for (std::size_t k = 0; k < w; ++k)
             {
-                output[0][0][index++] = input[i][j][k];
+                activations[0][0][index++] = input[i][j][k];
             }
         }
     }
 
-    activations = output;
-    return output;
+    return activations;
 }
 
 Tensor<double, 3> Flatten::backward_pass(const Tensor<double, 3> &input, const Tensor<double, 3> &output_derivatives)
@@ -53,11 +50,11 @@ Tensor<double, 3> Flatten::backward_pass(const Tensor<double, 3> &input, const T
     Tensor<double, 3> input_derivatives({static_cast<std::size_t>(d), static_cast<std::size_t>(h), static_cast<std::size_t>(w)});
 
     int index = 0;
-    for (int i = 0; i < d; ++i)
+    for (std::size_t i = 0; i < d; ++i)
     {
-        for (int j = 0; j < h; ++j)
+        for (std::size_t j = 0; j < h; ++j)
         {
-            for (int k = 0; k < w; ++k)
+            for (std::size_t k = 0; k < w; ++k)
             {
                 input_derivatives[i][j][k] = output_derivatives[0][0][index];
                 ++index;

--- a/bunjilearn/layers/flatten.cpp
+++ b/bunjilearn/layers/flatten.cpp
@@ -24,6 +24,7 @@ void Flatten::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_
     h = std::get<1>(set_input_shape);
     w = std::get<2>(set_input_shape);
     output_shape = std::make_tuple(1, 1, d * h * w);
+    activations = Tensor<double, 3>({1, 1, d * h * w});
     built = true;
 }
 

--- a/bunjilearn/layers/include/dense.hpp
+++ b/bunjilearn/layers/include/dense.hpp
@@ -8,14 +8,14 @@ namespace bunji
 class Dense : public Layer
 {
 private:
-    int units;
-    std::vector<std::vector<double>> weights;
-    std::vector<std::vector<double>> deriv_weights;
-    std::vector<double> biases;
-    std::vector<double> deriv_biases;
+    std::size_t units;
+    Tensor<double, 2> weights;
+    Tensor<double, 2> deriv_weights;
+    Tensor<double, 1> biases;
+    Tensor<double, 1> deriv_biases;
 public:
-    Dense(int units);
-    Dense(int inputs, int units);
+    Dense(std::size_t units);
+    Dense(std::size_t inputs, std::size_t units);
     void build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape) override;
 
     Tensor<double, 3> forward_pass(const Tensor<double, 3> &input) override;

--- a/bunjilearn/model/network.cpp
+++ b/bunjilearn/model/network.cpp
@@ -49,7 +49,6 @@ void Network::add_layer(Layer *layer)
 void Network::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_shape)
 {
     std::tuple<std::size_t, std::size_t, std::size_t> next_input = set_input_shape;
-    BUNJI_ERR("x:{}, y:{}, z:{}", std::get<0>(next_input), std::get<1>(next_input), std::get<2>(next_input));
     for (Layer *layer : layers)
     {
         if (layer->built)
@@ -65,7 +64,6 @@ void Network::build(std::tuple<std::size_t, std::size_t, std::size_t> set_input_
             layer->build(next_input);
             next_input = layer->get_output_shape();
         }
-        BUNJI_ERR("x:{}, y:{}, z:{}", std::get<0>(next_input), std::get<1>(next_input), std::get<2>(next_input));
     }
 }
 


### PR DESCRIPTION
- Activations now consider the entire 3D input.
- Instances of `int` in for loops have been changed to `std:;size_t`.
- Some unnessesary Tensor construtions have been removed which improves performance.